### PR TITLE
replaced cache_httpfs with custom cache system for Windows compatibility

### DIFF
--- a/defeatbeta_api/data/transcripts.py
+++ b/defeatbeta_api/data/transcripts.py
@@ -45,21 +45,12 @@ class Transcripts:
     def get_transcripts_list(self) -> pd.DataFrame:
         return self.transcripts
 
-    def get_transcript(self, fiscal_year: int, fiscal_quarter: int) -> str:
+    def get_transcript(self, fiscal_year: int, fiscal_quarter: int) -> pd.DataFrame:
         record = self._find_transcripts(fiscal_quarter, fiscal_year)
         if record.empty:
             raise ValueError(f"No transcript found for FY{fiscal_year} Q{fiscal_quarter}")
         df_paragraphs = _unnest(record)
-        # Format as simple text: "Speaker: content\n"
-        lines = []
-        for _, row in df_paragraphs.iterrows():
-            speaker = row.get('speaker', '').strip()
-            content = row.get('content', '').strip()
-            if speaker and content:
-                lines.append(f"{speaker}: {content}")
-            elif content:
-                lines.append(content)
-        return "\n\n".join(lines)
+        return df_paragraphs
 
     def analyze_financial_metrics_forecast_for_future_with_ai(self, fiscal_year: int, fiscal_quarter: int, llm: OpenAI, config: Optional[OpenAIConfiguration] = None) -> pd.DataFrame:
         conf = config if config is not None else OpenAIConfiguration()


### PR DESCRIPTION
Replaced `cache_httpfs` with a custom HTTP cache so make it compatible on Windows AND Linux.

## Major integration parts:

- `duckdb_client.py`:
    - Removed  `_validate_httpfs_cache()`

- `util.py`
    - Renamed `validate_httpfs_cache_directory()` to `validate_cache_directory()`

- `duckdb_conf.py`:
    - Removed all cache_httpfs settings
   - Set `cache_directory_name="defeat_cache"`

- New file: `\utils\local_http_cache.py`:
```python
class LocalHttpCache:
    """
    A persistent, file-based HTTP cache designed to replace cache_httpfs.
    
    Attributes:
        cache_dir (Path): The directory where cache files are stored.
        default_ttl (int): Default time-to-live in seconds (default: 86400 seconds which is 24 hours).
        debug (bool): If True, enables debug logging.
    """
```

- New file: `test\test_cache.py`:
    - Just run it to confirm the cache system works


- `hugging_face_client.py`:
```python
class HuggingFaceClient:
    def __init__(self, max_retries: int = 3, timeout: int = 30, cache_dir_name: str = "defeat_cache"):
        self.base_url = "https://huggingface.co/datasets/bwzheng2010/yahoo-finance-data"
        self.timeout = timeout

        cache_path = validate_cache_directory(cache_dir_name)
        self.cache = LocalHttpCache(cache_dir=cache_path, default_ttl=8*3600)  # cache live for 8 hours
```

- `sql_loader.py`:
```python
def load_sql(template_name: str, **kwargs) -> str:
    if not template_name or any(c in template_name for c in ['/', '\\', '..']):
        raise ValueError(f"Invalid template name: {template_name}")
    
    # use custom cache
    for key in list(kwargs.keys()):
        if key.endswith('url'):  # Matches 'url', 'stockholders_equity_url', etc.
            url_val = str(kwargs[key])
            if "read_parquet" not in url_val and not url_val.strip().upper().startswith("SELECT"):
                kwargs[key] = f"read_parquet('{url_val}')"
```

- At all `data/select_*` files changed:
```python
# Old:
SELECT * FROM '{url}' ...
# New:
SELECT * FROM {url} ...
```

- `ticker.py`:
   - Removed `download_data_performance()` 

- `treasure.py`:
```python
def daily_treasure_yield(self) -> pd.DataFrame:
        url = self.huggingface_client.get_url_path(daily_treasury_yield)
        # Old:  sql = f"SELECT * FROM '{url}'"
        # New: sql = f"SELECT * FROM read_parquet('{url}')"
        return self.duckdb_client.query(sql)
```



## Windows PoC

Here is the folder that the cache stores the data:
<img width="996" height="416" alt="image" src="https://github.com/user-attachments/assets/41ae3891-e7fb-402d-aced-b48b6baecc58" />

## How cache works and validates
```mermaid
flowchart LR
    A[ticker.price call] --> B[Build API URL]
    B --> C[Generate SHA256 hash]
    C --> D[Hash: 3857...3d8a41]
    D --> E{Cache .bin exists?}
    E -- No --> F[Download from API]
    F --> G[Write .bin file]
    F --> H[Write .json metadata]
    G --> I[Return local path]
    H --> I
    E -- Yes --> J{Check .json TTL}
    J -- Expired --> F
    J -- Valid --> K[Read from cache]
    K --> I
    I --> L[DuckDB reads .bin]
    L --> M[Return price data]

```

## Tested on
[X] Windows 11
[X] Debian GNU/Linux 13 (trixie)
[ ] MacOS (theoretically works from the moment it works on linux)