### PR TITLE
fix: don't crash DuckDBClient on httpfs cache validation failure

### DIFF
--- a/defeatbeta_api/client/duckdb_client.py
+++ b/defeatbeta_api/client/duckdb_client.py
@@ -91,7 +91,8 @@ class DuckDBClient:
 
         except Exception as e:
             self.logger.error(f"Failed to validate httpfs cache: {str(e)}")
-            raise
+            # Don't raise — cache validation failure should not prevent
+            # DuckDBClient from initializing.  Worst case: slightly stale data.
 
     def _read_cached_spec_update_time(self) -> Optional[str]:
         """Read update_time directly from the spec.json file on disk, bypassing DuckDB.


### PR DESCRIPTION
## Problem

When `_validate_httpfs_cache()` fails (network timeout, missing cache dir, HuggingFace API down), it raises an exception that prevents `DuckDBClient` from initializing entirely. This causes the defeatbeta provider to be unavailable, breaking the fallback chain in downstream services (e.g. AlphaGBM market data service).

In production logs, this manifested as repeated errors:
```
DuckDBClient - ERROR - Failed to validate httpfs cache: Cache clear failed. Expected: 2026-06-21T04:13:03Z, Got: 2026-06-30
```

## Fix

Remove the `raise` in the exception handler. Cache validation failure should log an error but not prevent the client from working — worst case is slightly stale cached data, which is far better than no data at all.